### PR TITLE
Remove log/pid file defaults

### DIFF
--- a/newrelic_redis_agent
+++ b/newrelic_redis_agent
@@ -6,10 +6,7 @@ require "dante"
 require "newrelic_plugin"
 require "redis"
 
-pid_path = File.expand_path("../run/newrelic_redis_agent.pid", __FILE__)
-log_path = File.expand_path("../log/newrelic_redis_agent.log", __FILE__)
-
-runner = Dante::Runner.new('newrelic_redis_agent', :pid_path  => pid_path, :log_path => log_path)
+runner = Dante::Runner.new('newrelic_redis_agent')
 runner.description = 'New Relic plugin agent for Redis'
 runner.with_options do |opts|
   opts.on('-c', '--config FILE', String, 'Specify configuration file') do |config|


### PR DESCRIPTION
Feels like it is better to just use the defaults provided by `dante` rather than defaulting relative to the script (e.g. I'm putting the ruby script in `/usr/local/bin` so it is trying to log to `/usr/local/log` by default). Even when not running in daemon mode, it appears like `dante` expects the log/run directories to exist anyway.

I realize this is personal opinion though, so I understand if you want to keep the behaviour.
